### PR TITLE
Set seed before each sim

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Suggests: 
     testthat (>= 2.1.0),
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# senlm 0.1.1
+
+* `simulate.senlm()` no longer re-seeds each sim.
+
 # senlm 0.1
 
 * First public release of the package.

--- a/R/MLE.R
+++ b/R/MLE.R
@@ -264,9 +264,18 @@ simulate.senlm <- function (object, nsim=1, seed=NULL, newdata=NULL, ...) {
   Dat <- as.data.frame(matrix(NA, ncol=nsim, nrow=length(newdata)))
   names(Dat) <- paste("sim_", 1:nsim, sep="")
 
+  ## Random number seed
+  if ( is.null (seed) ) {
+    ## Define seed if not given
+    seed <- as.numeric(paste(c(sample(1:9, 1), sample(0:9,(5-1))), collapse=""))
+  }
+  ## Set and store seed
+  set.seed (seed)
+  attr(Dat, 'seed') <- seed
+
   ## --- Simulate data
   for (i in 1:nsim) {
-    SimData <- simulate_data (x=newdata, Par=Par, seed=seed)
+    SimData <- simulate_data (x=newdata, Par=Par)
     Dat[,i] <- SimData$y
   }
 

--- a/R/MLE.R
+++ b/R/MLE.R
@@ -551,7 +551,7 @@ mle_default <- function (ModelInfo, Dat, theta0=NULL, conf.level=conf.level) {
     ## --- Calculate approximate confidence intervals
     if (StdErrOK) {
       ## Find confidence interval multiplier
-      mult <- qnorm((1 + conf.level)/2)
+      mult <- stats::qnorm((1 + conf.level)/2)
       u.lb <- u.theta - mult*u.stderr
       u.ub <- u.theta + mult*u.stderr
     } else {

--- a/R/MeanFunctions.R
+++ b/R/MeanFunctions.R
@@ -7,7 +7,8 @@
 #' parameters given in theta, at the points given by the vector x.
 #'
 #' @param ModelInfo A row from the output of set_models(), containing the
-#' mean_function and error distribution of the model in question.
+#'   mean_function and error distribution of the model in question. Or a string
+#'   in the form of "meanfun_errdist".
 #' @param theta Vector containing parameter values of model.
 #' @param x Values at which to calculate the mean function.
 #'
@@ -23,10 +24,14 @@
 #' @export
 mu_meanfunction <- function (ModelInfo, theta, x) {
   ## --- Calculate mean function at values x
-  
-  ## --- Create ModelInfo object if character string "err_dist-mean_fun" is supplied
-  if (class(ModelInfo)=="character") { ModelInfo <- set_model_info (ModelInfo) }
-  
+
+  ## --- Create ModelInfo object if character string "mean-fun_err-dist" is supplied
+  if (all(class(ModelInfo)=="character")) {
+    Names <- unlist (strsplit(ModelInfo, "_"))
+    ModelInfo <- set_model_info (mean_fun = Names[1],
+                                 err_dist = Names[2])
+  }
+
   ## --- Set model name
   model_name <- paste (ModelInfo$mean_fun, ModelInfo$err_dist, sep="_")
   

--- a/R/Models.R
+++ b/R/Models.R
@@ -830,7 +830,7 @@ estimate_delta <- function (y) {
 #' @examples
 #'
 #' ## Get parameters for a "gaussian-zinb" model
-#' get_parnames ("gaussian-zinb")
+#' get_parnames ("gaussian_zinb")
 #'
 #' @export
 #'

--- a/R/Sim.R
+++ b/R/Sim.R
@@ -986,7 +986,7 @@ rinversegaussian <- function (n, mu, phi) {
   if (length(mu) != n) { stop ("length of mu must be 1 or n!") }
     
   ## Sample from a normal distribution with a mean of 0 and 1 standard deviation
-  v  <- rnorm(n)
+  v  <- stats::rnorm(n)
 
   ## Create possible return value 
   y  <-  v^2

--- a/R/Sim.R
+++ b/R/Sim.R
@@ -1003,7 +1003,7 @@ rinversegaussian <- function (n, mu, phi) {
   x  <-  mu + (0.5 * phi * mu^2 * y) - (0.5 * mu * phi) * sqrt(4*mu*y/phi + mu^2*y^2)
 
   ## Perform test and set return value
-  Rand <-  runif(n)  
+  Rand <-  stats::runif(n)
   Test <- Rand <= mu/(mu+x)
   Result <- mu^2/x
   Result[Test] <- x[Test]
@@ -1047,8 +1047,7 @@ pinversegaussian <- function (q, mu, phi) {
   v <- sqrt(q * phi)
 
   ## --- Calculate cdf
-  Result <- pnorm((t - 1)/v) + exp(2/(mu * phi)) * pnorm(-(t + 1)/v)
-  
+  Result <- stats::pnorm((t - 1)/v) + exp(2/(mu * phi)) * stats::pnorm(-(t + 1)/v)
   ## --- CDF is zero if q is zero
   Result[q==0] <- 0
   Result[is.nan(Result)] <- 0

--- a/R/Sim.R
+++ b/R/Sim.R
@@ -320,7 +320,7 @@ create_default_par_list <- function (models=NULL,
 }
 
 
-simulate_data <- function (x, Par, seed=NULL) {
+simulate_data <- function (x, Par) {
   ## --- Simulate data
   
   ## --- Grab error distribution
@@ -329,16 +329,6 @@ simulate_data <- function (x, Par, seed=NULL) {
   ## Create data object
   Dat <- list()
 
-  ## Random number seed
-  if ( is.null (seed) ) {
-    ## Define seed if not given
-    seed <- as.numeric(paste(c(sample(1:9, 1), sample(0:9,(5-1))), collapse=""))
-  }
-  ## Set seed
-  set.seed (seed)
-  ## Store seed
-  Dat$seed <- seed
-  
   ## Calculate mean function
   mu <- do.call (paste("mu_", Par$mean_fun, sep=""), list(Par$thetaM, x))
   

--- a/R/Sim.R
+++ b/R/Sim.R
@@ -420,8 +420,8 @@ simulate_data <- function (x, Par) {
   if ( (err_dist == "zipl") | (err_dist == "zipl.mu") ) {
 
     ## Grab parameters
-    g0 <- as.list(Par$theta)$g0
-    g1 <- as.list(Par$theta)$g1
+    g0 <- as.list(Par$thetaE)$g0
+    g1 <- as.list(Par$thetaE)$g1
     NonZero <- (mu > 0)
 
     ## Create y vector
@@ -452,9 +452,9 @@ simulate_data <- function (x, Par) {
   if ( (err_dist == "zinbl") | (err_dist == "zinbl.mu") ) {
     
     ## Grab parameters
-    g0  <- as.list(Par$theta)$g0
-    g1  <- as.list(Par$theta)$g1
-    phi <- as.list(Par$theta)$phi
+    g0  <- as.list(Par$thetaE)$g0
+    g1  <- as.list(Par$thetaE)$g1
+    phi <- as.list(Par$thetaE)$phi
     NonZero <- (mu > 0)
 
     ## Convert mean and dispersion parameter to shape parameters of Gamma distribution
@@ -548,8 +548,8 @@ simulate_data <- function (x, Par) {
   if (err_dist == "zig" ) {
 
     ## Grab parameters
-    pi  <- as.list(Par$theta)$pi
-    phi <- as.list(Par$theta)$phi
+    pi  <- as.list(Par$thetaE)$pi
+    phi <- as.list(Par$thetaE)$phi
 
     ## --- Find where mean is positive
     NonZero <- (mu > 0)
@@ -583,9 +583,9 @@ simulate_data <- function (x, Par) {
   if ( (err_dist == "zigl") | (err_dist == "zigl.mu") ) {
 
     ## Grab parameters
-     g0  <- as.list(Par$theta)$g0
-    g1  <- as.list(Par$theta)$g1
-    phi <- as.list(Par$theta)$phi
+    g0  <- as.list(Par$thetaE)$g0
+    g1  <- as.list(Par$thetaE)$g1
+    phi <- as.list(Par$thetaE)$phi
 
     ## --- Find where mean is positive
     NonZero <- (mu > 0)
@@ -624,9 +624,9 @@ simulate_data <- function (x, Par) {
   if (err_dist == "ziig" ) {
     
     ## Grab parameters
-    pi  <- as.list(Par$theta)$pi
-    phi <- as.list(Par$theta)$phi
-    
+    pi  <- as.list(Par$thetaE)$pi
+    phi <- as.list(Par$thetaE)$phi
+
     ## --- Find where mean is positive
     NonZero <- (mu > 0)
     
@@ -655,10 +655,10 @@ simulate_data <- function (x, Par) {
   if ( (err_dist == "ziigl") | (err_dist == "ziigl.mu") ) {
     
     ## Grab parameters
-    g0  <- as.list(Par$theta)$g0
-    g1  <- as.list(Par$theta)$g1
-    phi <- as.list(Par$theta)$phi
-    
+    g0  <- as.list(Par$thetaE)$g0
+    g1  <- as.list(Par$thetaE)$g1
+    phi <- as.list(Par$thetaE)$phi
+
     ## --- Find where mean is positive
     NonZero <- (mu > 0)
     

--- a/man/get_parnames.Rd
+++ b/man/get_parnames.Rd
@@ -19,7 +19,7 @@ Get parameter names for given model.
 \examples{
 
 ## Get parameters for a "gaussian-zinb" model
-get_parnames ("gaussian-zinb")
+get_parnames ("gaussian_zinb")
 
 }
 \keyword{model}

--- a/man/mu_meanfunction.Rd
+++ b/man/mu_meanfunction.Rd
@@ -8,7 +8,8 @@ mu_meanfunction(ModelInfo, theta, x)
 }
 \arguments{
 \item{ModelInfo}{A row from the output of set_models(), containing the
-mean_function and error distribution of the model in question.}
+mean_function and error distribution of the model in question. Or a string
+in the form of "meanfun_errdist".}
 
 \item{theta}{Vector containing parameter values of model.}
 
@@ -18,8 +19,8 @@ mean_function and error distribution of the model in question.}
 Calculates the constant mean functions defined by thetaM at points x.
 }
 \description{
-Evalautes the mean function defined in ModelInfo, with the
-parameters given in theta, at the points given by the vector x.
+Evalautes the mean function defined in ModelInfo, with the parameters given
+in theta, at the points given by the vector x.
 }
 \examples{
 


### PR DESCRIPTION
Hey Andrew & team,

Just a small, and possibly trivial, change to stop `simulate.senlm` from re-seeding on each sim if seed is provided as argument. I imagine most users would set seed in their R script or Rmd instead and never encounter this. Just caught me out before so though may as well have a go at tweaking.

Before:

``` r
library(senlm)
data(haul)

# stats::simulate for comparison
m_lm <- lm(Sebastolobus.altivelis ~ depth, data = haul)
m_lm_sim <- simulate(m_lm, nsim = 5, seed = 0)
head(m_lm_sim)
#>         sim_1      sim_2     sim_3     sim_4     sim_5
#> 1717 559.2709  173.66223 -26.98326  273.1964 -236.2363
#> 1718 292.2682   73.46795 574.72621  263.9113  195.6283
#> 1719 396.2081 -212.53020 340.62905  548.4953  432.7915
#> 1720 771.9605  522.67281  82.38862  626.3130  437.2713
#> 1721 109.0541   23.14341 -77.43412 -115.2716  179.2241
#> 1722 230.7056  464.38746 617.12509  520.8010  303.0072
cov(m_lm_sim)
#>           sim_1     sim_2     sim_3     sim_4     sim_5
#> sim_1 103926.07  52121.52  54575.13  53016.24  53206.57
#> sim_2  52121.52 113195.66  52693.84  58206.09  57614.44
#> sim_3  54575.13  52693.84 105276.35  56628.61  57704.60
#> sim_4  53016.24  58206.09  56628.61 108857.00  55684.39
#> sim_5  53206.57  57614.44  57704.60  55684.39 113522.73

# senlm::simulate.senlm
m_senlm <- senlm(data = haul,
                 xvar = 'depth',
                 yvar = 'Sebastolobus.altivelis', 
                 mean_fun = 'gaussian',
                 err_dist = 'zip')
m_senlm_sim <- simulate(m_senlm, nsim = 5, seed = 0)
head(m_senlm_sim)
#>   sim_1 sim_2 sim_3 sim_4 sim_5
#> 1   200   200   200   200   200
#> 2   448   448   448   448   448
#> 3     0     0     0     0     0
#> 4     0     0     0     0     0
#> 5     0     0     0     0     0
#> 6     0     0     0     0     0
cov(m_senlm_sim)
#>          sim_1    sim_2    sim_3    sim_4    sim_5
#> sim_1 29291.65 29291.65 29291.65 29291.65 29291.65
#> sim_2 29291.65 29291.65 29291.65 29291.65 29291.65
#> sim_3 29291.65 29291.65 29291.65 29291.65 29291.65
#> sim_4 29291.65 29291.65 29291.65 29291.65 29291.65
#> sim_5 29291.65 29291.65 29291.65 29291.65 29291.65
```

<sup>Created on 2021-09-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

After:

``` r
library(senlm)
m_senlm <- senlm(data = haul,
                 xvar = 'depth',
                 yvar = 'Sebastolobus.altivelis', 
                 mean_fun = 'gaussian',
                 err_dist = 'zip')
m_senlm_sim <- simulate(m_senlm, nsim = 5, seed = 0)
head(m_senlm_sim)
#>   sim_1 sim_2 sim_3 sim_4 sim_5
#> 1   200     0     0     0   180
#> 2   448     0     0     0   460
#> 3     0     0    15     0     0
#> 4     0   826     0   737     0
#> 5     0     0     4     0     1
#> 6     0     0     0     0   752
cov(m_senlm_sim)
#>           sim_1     sim_2     sim_3    sim_4     sim_5
#> sim_1 29291.652  8885.064  7823.682  6481.41  8485.978
#> sim_2  8885.064 36671.369 11325.707 11220.77 11877.148
#> sim_3  7823.682 11325.707 34469.746 10621.45 12055.704
#> sim_4  6481.410 11220.774 10621.446 37921.73 14115.738
#> sim_5  8485.978 11877.148 12055.704 14115.74 38667.271
```

<sup>Created on 2021-09-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

The only other call to `simulate_data` was in `create_simulated_datasets` - this was handling the seed itself and not passing to `simulate_data` so wasn't (shouldn't have been) affected by the change. Quick checks before and after looked all good.

The first commit was just small tweaks to get `devtools::check()` to play nice on my end.

Thanks heaps for this package, all documentation/functions are really helpful and fun to look at the trawl data with!
Hayden